### PR TITLE
Migrate to CDK v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: '14'
       - name: Setup (Module)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,143 +5,144 @@
   "requires": true,
   "dependencies": {
     "@aws-cdk/assert": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assert/-/assert-1.142.0.tgz",
-      "integrity": "sha512-4JC0LaiC9UDAyPKs70gJhIZmuRWujj2mVXfcjIEckYNkjQz8IyLcmcNGlx0s7kyTZaerwybiTPj23S3yYhWSnQ==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assert/-/assert-1.143.0.tgz",
+      "integrity": "sha512-oRzKOlsD77iW0Nq7QZNL33LngkfZIxoWMj2KD2IfbOn7YzYC+3msh7OZsj8BDZMIm++5xpmkcs77gJLKiKtIJw==",
       "dev": true,
       "requires": {
-        "@aws-cdk/cloudformation-diff": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
-        "@aws-cdk/cx-api": "1.142.0",
+        "@aws-cdk/cloudformation-diff": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
+        "@aws-cdk/cx-api": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/assets": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.142.0.tgz",
-      "integrity": "sha512-KeZx9RcTDDijDjUTZ2wZOHzte16/v1Rnj9nr5gkt592RUQ9jiePLfsWSiM20sXDo5nUH8pPhuTBDADVazKlrcg==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.143.0.tgz",
+      "integrity": "sha512-kvA3ELsH1CEzBxc8czh94xqtmyeOqAybHUE1Np6IF4xmsbAx/dHxImbRtTsPVq6wBw+XZizTQyF4fT41f4CRgg==",
       "dev": true,
       "requires": {
-        "@aws-cdk/core": "1.142.0",
-        "@aws-cdk/cx-api": "1.142.0",
+        "@aws-cdk/core": "1.143.0",
+        "@aws-cdk/cx-api": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-applicationautoscaling": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.142.0.tgz",
-      "integrity": "sha512-Hq2YfN+BJLHdnTbX0UlAotI80HXT8Z3rlxbl0uxTP3pXjs0mUugVyRzpUbbuSbNgKtBVyp0r4MfSVYHPgMD/Zw==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.143.0.tgz",
+      "integrity": "sha512-ABgW+2dCbbnqtV5/Ylt7QBOvoHAAnB233Pib6/hlPGIzXFuCraCizWmB/0Lq694OlMV7XviZbOUmizlChrIYPA==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-autoscaling-common": "1.142.0",
-        "@aws-cdk/aws-cloudwatch": "1.142.0",
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
+        "@aws-cdk/aws-autoscaling-common": "1.143.0",
+        "@aws-cdk/aws-cloudwatch": "1.143.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-autoscaling-common": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.142.0.tgz",
-      "integrity": "sha512-RGUdIh6kVcp9OzsbY7ibYw5n/ExSSIcd+WxX+q/B1+USHZpJ0XbtC1ABoaSP+KTwM5Uxvf7Fl0YmBGOkv/7k8Q==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.143.0.tgz",
+      "integrity": "sha512-LItj+iq6lQMqwsxxOtVXMNR85+lIkMHCmj2hZ/tSgkZCHrvGJPiV6H71b8saaq+U+tE94udp0i/HZ0pGDf5gZQ==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-cloudformation": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.142.0.tgz",
-      "integrity": "sha512-RSCKu9tPzcMiEXu4yEkYlJwtlnx4Q2SsgxxNxzkIMrO+tg7m9qLeZEPQHrChs75RnFMwCAHPfwA+sXHgnFsRGQ==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.143.0.tgz",
+      "integrity": "sha512-26gPxCeO+jbxcwe28wdLWmdRA0xcTTBu5PcgFWjIBklSVEyhDZ5wac9MB0eIODDigjjl/A/O//4ZzYkts8Rrjw==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/aws-lambda": "1.142.0",
-        "@aws-cdk/aws-s3": "1.142.0",
-        "@aws-cdk/aws-sns": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
-        "@aws-cdk/cx-api": "1.142.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/aws-lambda": "1.143.0",
+        "@aws-cdk/aws-s3": "1.143.0",
+        "@aws-cdk/aws-sns": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
+        "@aws-cdk/cx-api": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-cloudwatch": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.142.0.tgz",
-      "integrity": "sha512-qvmpDVHLscrntmm31kTVnA1JLpc7e5Ca60ce0bPh/5cDiv1Xr7a5B5eDn7kSXxzlHCVD4j/rjwwMmBTxL1G1YQ==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.143.0.tgz",
+      "integrity": "sha512-wpKhKBrMGFLJ4TmvaUhIyO9oewTVWCujSLULdTFNZA8OgpoEqhbQzR8jdJmtaeprqlL15eOG4UcdTZNWymQGYA==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-codeguruprofiler": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.142.0.tgz",
-      "integrity": "sha512-yYKPTiafXxPtz1IarCLa+ftLBrU7DaWHY89zyBmQgFNuhuSSHSysqTIq1CwxVT4niAJMPtRCvoXLZ+4WRFdxMQ==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.143.0.tgz",
+      "integrity": "sha512-M/dVj3O8B7VmJwDqKWPtQZqync6K3oNy0aV/dhRxmuG1voavQ7+GX8BAENYpzmr9qSaVl5/fd3xHQ1YHb95AIg==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-codestarnotifications": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.142.0.tgz",
-      "integrity": "sha512-MiFd3GSrz5K4/0nab8dQlOkyXpuy0VDXd8gneNdRbZHlhKpHaAqWm3v/CnlzfJq+4TC3wuo7Q4ThRZ8RLLUFZw==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.143.0.tgz",
+      "integrity": "sha512-QS1iBZmYrDAouYwR8ROACRoSBlY8tr6DExOgJrEbrWQqMWMEIYVFYkP4MxVdT4MJHHyQ0vZBm4fSKGRVNa/O+w==",
       "dev": true,
       "requires": {
-        "@aws-cdk/core": "1.142.0",
+        "@aws-cdk/core": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-ec2": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.142.0.tgz",
-      "integrity": "sha512-BgDJaFjwYto3emnWJBJsRZnINKDiInWJJ/20XrNG6wBIVS0wSU/yOvW34nebm09xK2BLhRCK6IrrY/pjzR7wNA==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.143.0.tgz",
+      "integrity": "sha512-94fubTVf8JoOv8vv0Wfl+EdB+4dSBcawTaeB9dbv5ChEvzlCNyR6o1XjufN19v0xI/HXeZdSj86sgxkZhT6tVA==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.142.0",
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/aws-kms": "1.142.0",
-        "@aws-cdk/aws-logs": "1.142.0",
-        "@aws-cdk/aws-s3": "1.142.0",
-        "@aws-cdk/aws-s3-assets": "1.142.0",
-        "@aws-cdk/aws-ssm": "1.142.0",
-        "@aws-cdk/cloud-assembly-schema": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
-        "@aws-cdk/cx-api": "1.142.0",
-        "@aws-cdk/region-info": "1.142.0",
+        "@aws-cdk/aws-cloudwatch": "1.143.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/aws-kms": "1.143.0",
+        "@aws-cdk/aws-logs": "1.143.0",
+        "@aws-cdk/aws-s3": "1.143.0",
+        "@aws-cdk/aws-s3-assets": "1.143.0",
+        "@aws-cdk/aws-ssm": "1.143.0",
+        "@aws-cdk/cloud-assembly-schema": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
+        "@aws-cdk/cx-api": "1.143.0",
+        "@aws-cdk/region-info": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-ecr": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.142.0.tgz",
-      "integrity": "sha512-RrPleH4JOiO067KTeofzTaqK5Lxxekkkk1jYVdVxFRcFi4KU1745/nH0OaypDsoCyd4vTHkjq8jBVGKJkNg2lQ==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.143.0.tgz",
+      "integrity": "sha512-rg8gh8Q5ac1Dog73Dgp4mZ0gTKCDBrtHnDl00cRxanIMa6f3Qtjw352cKWDy0baXR65PvYCXFAPrEm0QBFtcRw==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-events": "1.142.0",
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
+        "@aws-cdk/aws-events": "1.143.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/aws-kms": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-ecr-assets": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.142.0.tgz",
-      "integrity": "sha512-5Bxhevuid7D1NNNISSf4MbxfEEWXYvfMBFFgMK4zxGh2IyoX3yEEbaCD3dJCV/zrTf+IqBulfYrhT9kdFKvfKw==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.143.0.tgz",
+      "integrity": "sha512-c7aV9TjTDHwi1KheSiUc51G5scxSJJuJ/RPDGI0jHtQk4hm4JjGtH3Y3TYCyJY4dfqHYSqL45kYelSNBOwHYQg==",
       "dev": true,
       "requires": {
-        "@aws-cdk/assets": "1.142.0",
-        "@aws-cdk/aws-ecr": "1.142.0",
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/aws-s3": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
-        "@aws-cdk/cx-api": "1.142.0",
+        "@aws-cdk/assets": "1.143.0",
+        "@aws-cdk/aws-ecr": "1.143.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/aws-s3": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
+        "@aws-cdk/cx-api": "1.143.0",
         "constructs": "^3.3.69",
         "minimatch": "^3.0.4"
       },
@@ -176,197 +177,197 @@
       }
     },
     "@aws-cdk/aws-efs": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.142.0.tgz",
-      "integrity": "sha512-nfOpy76TDjQOUh/lV6IxGsVEyDzjtwmjMjl56qZGZC8riVd880DG2YyhnNT1VVYC/rV2CrVzw+q+jtTCnqEcpg==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.143.0.tgz",
+      "integrity": "sha512-kOYSfB03glTsZOwDB482FCxYLKCqEsKiP2b1zWMuPWySgk5f+lH9/Mcpa2BAry0/u4CAeZx1HYdhOKhWmqvQoA==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-ec2": "1.142.0",
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/aws-kms": "1.142.0",
-        "@aws-cdk/cloud-assembly-schema": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
-        "@aws-cdk/cx-api": "1.142.0",
+        "@aws-cdk/aws-ec2": "1.143.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/aws-kms": "1.143.0",
+        "@aws-cdk/cloud-assembly-schema": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
+        "@aws-cdk/cx-api": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-events": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.142.0.tgz",
-      "integrity": "sha512-VeJH3W762latAANShjgMF+uf5PCvcVkay2VBA+1P5nxfOOBD+X4ziMHulL/iSduNbOyvKPL2JS4HvAsBdxvyHw==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.143.0.tgz",
+      "integrity": "sha512-2mS9ZiuEZ6Y2/K9g53ZOinIjbSYCfrxxPQ7p7zshfYIrWTTPJ72/CJo/JLJXjEWxXPn70Bnu++uCh7Mw8NvZKQ==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-iam": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.142.0.tgz",
-      "integrity": "sha512-KePh4nC4mpwjnS3epFEfibVJ7uAbYEq0kmOYbLmEAmw4p6k3FyrEIJm8+BUL13Eut8Fv7bxTCjtqrlSh3RjzbQ==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.143.0.tgz",
+      "integrity": "sha512-5MbpklDGslsbLZIej1+I9bg/WSCxB0rTBzG5AW2745C85r/+oOALtH5mRy3365BvCJHj2nqitoutiBMMWvCgfQ==",
       "dev": true,
       "requires": {
-        "@aws-cdk/core": "1.142.0",
-        "@aws-cdk/region-info": "1.142.0",
+        "@aws-cdk/core": "1.143.0",
+        "@aws-cdk/region-info": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-kms": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.142.0.tgz",
-      "integrity": "sha512-cPNqHD+bA7pSxm9wu8Apgz3SPzfQiiGImnt/NhM0xRAivEM3UmjfOvZQVPHRWXdXrV4AliNx+fGK635GW7+tuQ==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.143.0.tgz",
+      "integrity": "sha512-EtsL/eNYfwk3o2MLJjAE1gJKBOs4ogsA18M/o2+iP55/IN5BA+EMy0xxNXZ1dqbdBF7k/IUXgTvNOI0BeHRigA==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/cloud-assembly-schema": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
-        "@aws-cdk/cx-api": "1.142.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/cloud-assembly-schema": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
+        "@aws-cdk/cx-api": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-lambda": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.142.0.tgz",
-      "integrity": "sha512-Vf1Zk2dOFdONgPkzoo0igi+edT784066fNdbkjzyRyDW8j6eCt1TWHwmr+BF3fduETOonAMW0L4c+fLPynVejQ==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.143.0.tgz",
+      "integrity": "sha512-IsaKtmLla6Y65bNlh/bILXoRxaHuBxjA55k+Pg17Dn8d9KrE2skHAjMffzuq/v5yZK4SyZs6o2vml8c5c5BMUw==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-applicationautoscaling": "1.142.0",
-        "@aws-cdk/aws-cloudwatch": "1.142.0",
-        "@aws-cdk/aws-codeguruprofiler": "1.142.0",
-        "@aws-cdk/aws-ec2": "1.142.0",
-        "@aws-cdk/aws-ecr": "1.142.0",
-        "@aws-cdk/aws-ecr-assets": "1.142.0",
-        "@aws-cdk/aws-efs": "1.142.0",
-        "@aws-cdk/aws-events": "1.142.0",
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/aws-kms": "1.142.0",
-        "@aws-cdk/aws-logs": "1.142.0",
-        "@aws-cdk/aws-s3": "1.142.0",
-        "@aws-cdk/aws-s3-assets": "1.142.0",
-        "@aws-cdk/aws-signer": "1.142.0",
-        "@aws-cdk/aws-sqs": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
-        "@aws-cdk/cx-api": "1.142.0",
-        "@aws-cdk/region-info": "1.142.0",
+        "@aws-cdk/aws-applicationautoscaling": "1.143.0",
+        "@aws-cdk/aws-cloudwatch": "1.143.0",
+        "@aws-cdk/aws-codeguruprofiler": "1.143.0",
+        "@aws-cdk/aws-ec2": "1.143.0",
+        "@aws-cdk/aws-ecr": "1.143.0",
+        "@aws-cdk/aws-ecr-assets": "1.143.0",
+        "@aws-cdk/aws-efs": "1.143.0",
+        "@aws-cdk/aws-events": "1.143.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/aws-kms": "1.143.0",
+        "@aws-cdk/aws-logs": "1.143.0",
+        "@aws-cdk/aws-s3": "1.143.0",
+        "@aws-cdk/aws-s3-assets": "1.143.0",
+        "@aws-cdk/aws-signer": "1.143.0",
+        "@aws-cdk/aws-sqs": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
+        "@aws-cdk/cx-api": "1.143.0",
+        "@aws-cdk/region-info": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-logs": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.142.0.tgz",
-      "integrity": "sha512-KAmG/S1A4C9p6IBbNgdoVzZ2SYNA8UHeof5XmRLi+LEqRKn1fTUSGtI+FgURZ+q2QrZAiRotAE3roDEWqingyw==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.143.0.tgz",
+      "integrity": "sha512-6G9Ttp9jDvNSqiwBhNDyzdoa2CX/rdULqTKoJe6kfEhSX61AdM3+s4zZhvtixLDYfygJS7XV07hG5KwU4231XA==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.142.0",
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/aws-kms": "1.142.0",
-        "@aws-cdk/aws-s3-assets": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
-        "@aws-cdk/cx-api": "1.142.0",
+        "@aws-cdk/aws-cloudwatch": "1.143.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/aws-kms": "1.143.0",
+        "@aws-cdk/aws-s3-assets": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
+        "@aws-cdk/cx-api": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-route53": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.142.0.tgz",
-      "integrity": "sha512-aIGts0Or08xE6hHpCMFV0YLU13YtsGVGu5sugkqWQeNE24lzMT1M0JIcj1m5uxomEs/2qihIQqp9c8x6vGyRag==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.143.0.tgz",
+      "integrity": "sha512-4AO+3E8IP6bLchdwK9SeUMWjEx8nK71UlDMXt+rnQldmCL4k5H28mq5cu3DkLUWajwTdqXqs4IJsy086RyjlOQ==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-ec2": "1.142.0",
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/aws-logs": "1.142.0",
-        "@aws-cdk/cloud-assembly-schema": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
-        "@aws-cdk/custom-resources": "1.142.0",
+        "@aws-cdk/aws-ec2": "1.143.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/aws-logs": "1.143.0",
+        "@aws-cdk/cloud-assembly-schema": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
+        "@aws-cdk/custom-resources": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-s3": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.142.0.tgz",
-      "integrity": "sha512-fIW8mVRUtB9s25hEPOP543hdebGcQtQEVL/9BGnVJ2uIwB3zvUrFk9TSJFo0Qq33w0vuIL9/LPAcZQTIV4x1CA==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.143.0.tgz",
+      "integrity": "sha512-J23Tk3mFgRj1kzbOPcCdidiOR3CUfqnwFn9LhCT2zG0+gWd3cHV3YmdGnhrH4TqYh/J3aD/lPzh7d85d9nSwVA==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-events": "1.142.0",
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/aws-kms": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
-        "@aws-cdk/cx-api": "1.142.0",
+        "@aws-cdk/aws-events": "1.143.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/aws-kms": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
+        "@aws-cdk/cx-api": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-s3-assets": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.142.0.tgz",
-      "integrity": "sha512-kfjtZ2h73fHtT/sjSXGw2EcD2xrYY8z7QrIlWq2w8E5oq/EGr2Bmm6a0hDS/Ezg8ajbcvnAtdQNHSZS3nyTeqg==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.143.0.tgz",
+      "integrity": "sha512-tvJUvIWyXXjFB0jLt5sKYf+gwC8lHKTJmq0UzEtVVGKYbvPYscK9frXMbglQTJ3m9cdksuZN98QrIzCWnQEs3A==",
       "dev": true,
       "requires": {
-        "@aws-cdk/assets": "1.142.0",
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/aws-kms": "1.142.0",
-        "@aws-cdk/aws-s3": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
-        "@aws-cdk/cx-api": "1.142.0",
+        "@aws-cdk/assets": "1.143.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/aws-kms": "1.143.0",
+        "@aws-cdk/aws-s3": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
+        "@aws-cdk/cx-api": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-signer": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.142.0.tgz",
-      "integrity": "sha512-jKvOJp+D4CIcfCAT3HYiOvJRer+vwqcGcFbm6puHGN8euUZ8UiNdiqBPEsoHb/ccdsuiKBolTEuZJppCmylwbw==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.143.0.tgz",
+      "integrity": "sha512-ID6EMGwJrR2aF3BQ/pJHmp6j1GFgdYYmbmd0bPg0qh/GJMBPQpvn4DE+dMoeZoZ75PMBOMtoV8immxOEXKsu5A==",
       "dev": true,
       "requires": {
-        "@aws-cdk/core": "1.142.0",
+        "@aws-cdk/core": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-sns": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.142.0.tgz",
-      "integrity": "sha512-QTDojafyKi9YNiOkYmn/jPWrlbSYwFX8UYMMQfajaL2w94Xk1WMOyZzFJnaoFxPhTBYEi8AZtKWXruDeFmz+VA==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.143.0.tgz",
+      "integrity": "sha512-BfOL2Hugsn+60uynAh5NyDLHE+ulNilTFiIJW973TV4AOaW1Gu8h7rZYkQL0T0VuIQOBVO9K9gtwcFOYYwlC0A==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.142.0",
-        "@aws-cdk/aws-codestarnotifications": "1.142.0",
-        "@aws-cdk/aws-events": "1.142.0",
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/aws-kms": "1.142.0",
-        "@aws-cdk/aws-sqs": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
+        "@aws-cdk/aws-cloudwatch": "1.143.0",
+        "@aws-cdk/aws-codestarnotifications": "1.143.0",
+        "@aws-cdk/aws-events": "1.143.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/aws-kms": "1.143.0",
+        "@aws-cdk/aws-sqs": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-sqs": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.142.0.tgz",
-      "integrity": "sha512-bzYCT4/y9wsr3cbk9Kyimhur5s3ERTsPbJbpknK0l/4+qIMh2EY5INmFGz0jY4e8YM3pLjxASr6MJPgNeLwAeA==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.143.0.tgz",
+      "integrity": "sha512-O4kbVWQ70kalY0SY3hfu646sEbF3hpulc1AiYevsNC8CQ5WFSghhj0LVhrlZMKnOHDr/zdOp+M/5Ydm7bVTRIA==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.142.0",
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/aws-kms": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
+        "@aws-cdk/aws-cloudwatch": "1.143.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/aws-kms": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-ssm": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.142.0.tgz",
-      "integrity": "sha512-pqVvnTnOTpp1A+x7XDF8tUQFTEuBk5wMIOjz3KHtVIsaMdrijTkhUGWp3IpDiARdIwPvPI366LIbB/PVjQJ4KA==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.143.0.tgz",
+      "integrity": "sha512-AACufj9LEta/uXKEzVHHFUxB+J0uoHWKpMWpqhWJKJWIHuiDMPnqrvk9Mofo+vP0hfMV54nQ+PGoJsMRGcP1Aw==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/aws-kms": "1.142.0",
-        "@aws-cdk/cloud-assembly-schema": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/aws-kms": "1.143.0",
+        "@aws-cdk/cloud-assembly-schema": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/cfnspec": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.142.0.tgz",
-      "integrity": "sha512-M8SAe3r6PgOcjdJ+XuZ+WJQ249JyFvobkCbHnxVyHMgYAXpPnhwc5zgcZfC4jyVb6f2wbLuzDQKSbH1QC4UdyQ==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.143.0.tgz",
+      "integrity": "sha512-f3jP3ndX74aoauI73lgNGr+il0GW6tj7JIA3F22H7zUBvvbfSgq9LUpQ9oTseObvz86LE3EEXmmUYGD3tjZrHw==",
       "dev": true,
       "requires": {
         "fs-extra": "^9.1.0",
@@ -374,9 +375,9 @@
       }
     },
     "@aws-cdk/cloud-assembly-schema": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.142.0.tgz",
-      "integrity": "sha512-Cn9jYWga+Zmtvl3cvtYodQcOZe2CGxgCK9Rm9Cfq+5WcwaRxh50LQSlakOKIEbdd1pLtB8jKXl0bo9TIE6J9dg==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.143.0.tgz",
+      "integrity": "sha512-HRtFEDFkqPGDmRTgRUFL3tIKyL3RUbUggWIp8+esguX5t2eR1u2JNb2tBYWb5ZXPrbEREeVpT6xW66eIZRiadQ==",
       "dev": true,
       "requires": {
         "jsonschema": "^1.4.0",
@@ -412,12 +413,12 @@
       }
     },
     "@aws-cdk/cloudformation-diff": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.142.0.tgz",
-      "integrity": "sha512-qxMNPb3kyqPIaAJZmk1h0ziy1lw6M3DIxja3QrZvfpR8InX15eTQoq/5LdBifoXTAgbEDRQ3i7sGhy8bDC4V0Q==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.143.0.tgz",
+      "integrity": "sha512-lzu7sGszKXAVgyYiyC52vGHtTillajq6yiki9vBQR4wlmrtyB/uzTUqKOS+lAberMyJ+vsNkOQEeMNKBs6VkDA==",
       "dev": true,
       "requires": {
-        "@aws-cdk/cfnspec": "1.142.0",
+        "@aws-cdk/cfnspec": "1.143.0",
         "@types/node": "^10.17.60",
         "chalk": "^4",
         "diff": "^5.0.0",
@@ -435,14 +436,14 @@
       }
     },
     "@aws-cdk/core": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.142.0.tgz",
-      "integrity": "sha512-qM+e97MqEEghoQai4NXqHsW7r7AI0kLW9HmZh8v/Vzqw/1XopEZbBR3TUWShwh32D1e23L9vmHZoiiMLt02sEQ==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.143.0.tgz",
+      "integrity": "sha512-lhb1HvkaBow+4M73UI95b3Rth1evvK2TjprQjjjgBmA0RcheQB9kKYE6eYOaEa3T4K1/Xst/dOTGKMLUMKShlQ==",
       "dev": true,
       "requires": {
-        "@aws-cdk/cloud-assembly-schema": "1.142.0",
-        "@aws-cdk/cx-api": "1.142.0",
-        "@aws-cdk/region-info": "1.142.0",
+        "@aws-cdk/cloud-assembly-schema": "1.143.0",
+        "@aws-cdk/cx-api": "1.143.0",
+        "@aws-cdk/region-info": "1.143.0",
         "@balena/dockerignore": "^1.0.2",
         "constructs": "^3.3.69",
         "fs-extra": "^9.1.0",
@@ -525,28 +526,28 @@
       }
     },
     "@aws-cdk/custom-resources": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.142.0.tgz",
-      "integrity": "sha512-reyE/7DkORxzAY0WY3t5yS1w4JbNP0JI1kGq7Z/ExbwVBky/5U91fFcQm0010sCvm9/APPljXrw1Pw2oEFtZdQ==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.143.0.tgz",
+      "integrity": "sha512-EBEXTEKinSvAyNXL3M/sqU3bdE62t8DctI4R9p1S3nNvolUCjYdPOtReZPBgibbb956y3Q/1BI79tOQyp3Dgbg==",
       "dev": true,
       "requires": {
-        "@aws-cdk/aws-cloudformation": "1.142.0",
-        "@aws-cdk/aws-ec2": "1.142.0",
-        "@aws-cdk/aws-iam": "1.142.0",
-        "@aws-cdk/aws-lambda": "1.142.0",
-        "@aws-cdk/aws-logs": "1.142.0",
-        "@aws-cdk/aws-sns": "1.142.0",
-        "@aws-cdk/core": "1.142.0",
+        "@aws-cdk/aws-cloudformation": "1.143.0",
+        "@aws-cdk/aws-ec2": "1.143.0",
+        "@aws-cdk/aws-iam": "1.143.0",
+        "@aws-cdk/aws-lambda": "1.143.0",
+        "@aws-cdk/aws-logs": "1.143.0",
+        "@aws-cdk/aws-sns": "1.143.0",
+        "@aws-cdk/core": "1.143.0",
         "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/cx-api": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.142.0.tgz",
-      "integrity": "sha512-5QVYD8CMkkQ/i2A4MQEj58aWVXc46qc+is/CNwLywUhNxzVZz1qvwoZaXOrLIBMFzRDsKZ/aUdm1Qh5meznhXg==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.143.0.tgz",
+      "integrity": "sha512-Clz2rF4URVDT0OXFJDxdaXjadaj8SKJB/FYEy/0Y06AEbXWg0bcF/hCbcyGf3PIgOZwoRtM/U3KnLcReofSDcQ==",
       "dev": true,
       "requires": {
-        "@aws-cdk/cloud-assembly-schema": "1.142.0",
+        "@aws-cdk/cloud-assembly-schema": "1.143.0",
         "semver": "^7.3.5"
       },
       "dependencies": {
@@ -574,9 +575,9 @@
       }
     },
     "@aws-cdk/region-info": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.142.0.tgz",
-      "integrity": "sha512-74AX+RtqvX9rOqi+1RSYs2yXLLb+pACS4iWDgG9MyK5KwDPfAQb7HjpnlQ8teENGRLvdnqlWF3aK2oypGTf1sA==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.143.0.tgz",
+      "integrity": "sha512-0MhXA5EkZuwr+0Y3jDRsZi/NDQ5vZyQt88mylcpHifpwkqlZd0j7pU0rWBFjHBbmPnYdj7ahDwl2oKP2pQ1pgQ==",
       "dev": true
     },
     "@babel/code-frame": {
@@ -2601,9 +2602,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "3.3.205",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.205.tgz",
-      "integrity": "sha512-l1c14p2mBQgE9ZxfVo5Er7390kZ0IWdHA8aU8Q1ZT/+BtqBSaEq9BCJ3ckG3r9zygZfFho1AZ1b1pKwozQFddQ==",
+      "version": "3.3.207",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.207.tgz",
+      "integrity": "sha512-2y0qFKJZav6NJjgN9T+m7TUSRvOAQ+0vVDJWGrpwgf7BRS6AoY643Z/O1ck9ZOuH4DpvW0ElnzbAXLaFwLPtEg==",
       "dev": true
     },
     "conventional-changelog-angular": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6265,7 +6265,7 @@
           "dev": true
         },
         "json-schema": {
-          "version": "0.2.3",
+          "version": "0.4.0",
           "bundled": true,
           "dev": true
         },
@@ -6290,13 +6290,13 @@
           "dev": true
         },
         "jsprim": {
-          "version": "1.4.1",
+          "version": "1.4.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
+            "json-schema": "0.4.0",
             "verror": "1.10.0"
           }
         },

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "@aws-cdk/core": "^1.98.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.142.0",
-    "@aws-cdk/aws-iam": "1.142.0",
-    "@aws-cdk/aws-lambda": "1.142.0",
-    "@aws-cdk/aws-route53": "1.142.0",
-    "@aws-cdk/core": "1.142.0",
+    "@aws-cdk/assert": "1.143.0",
+    "@aws-cdk/aws-iam": "1.143.0",
+    "@aws-cdk/aws-lambda": "1.143.0",
+    "@aws-cdk/aws-route53": "1.143.0",
+    "@aws-cdk/core": "1.143.0",
     "@prescott/commitlint-preset": "1.0.3",
     "@prescott/semantic-release-config": "1.0.1",
     "@prescott/tslint-preset": "1.0.1",


### PR DESCRIPTION
Migrate to CDK v2
https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html

Migrate tests @aws-cdk/assert (deprecated) -> aws-cdk-lib/assertions
https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/assertions/MIGRATING.md